### PR TITLE
Removing socket.flush()

### DIFF
--- a/server/nodegame/ws.js
+++ b/server/nodegame/ws.js
@@ -54,7 +54,6 @@ function Connection($, req, socket, headers, upgradeHeader) {
             data += '\r\n\r\n';
             data += hash.digest('binary');
             socket.write(data, 'binary');
-            socket.flush();
         }
     
     } else {
@@ -66,7 +65,6 @@ function Connection($, req, socket, headers, upgradeHeader) {
          
         data += '\r\n\r\n';
         socket.write(data, 'ascii');
-        socket.flush();
     }  
     
     // Internal Stuff
@@ -118,7 +116,6 @@ function Connection($, req, socket, headers, upgradeHeader) {
                     bytes += Buffer.byteLength(data);
                 }
                 socket.write('\xff', 'binary'); 
-                socket.flush();
                 bytes += 2;
             
             } catch(e) {


### PR DESCRIPTION
Hi,
After I edited to remove references to socket.flush(), the client and server code seemed to run with Node 0.5.8

Thanks,
Jeyan
